### PR TITLE
Reduce spacing and boxshadow around cards

### DIFF
--- a/src/components/dashboard/Explore.js
+++ b/src/components/dashboard/Explore.js
@@ -17,12 +17,12 @@ const useStyles = makeStyles((theme) => ({
   cardGrid: {
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
-    paddingRight: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
   },
   movieCard: {
     "&:hover": {
-    boxShadow: '0px 0px 2px 2px black',
+    boxShadow: '0px 0px 1px 1px black',
     backgroundColor:'black',
     },
   },

--- a/src/components/dashboard/Ratings.js
+++ b/src/components/dashboard/Ratings.js
@@ -16,12 +16,12 @@ const useStyles = makeStyles((theme) => ({
   cardGrid: { 
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
-    paddingRight: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
   },
   movieCard: {
     "&:hover": {
-    boxShadow: '0px 0px 2px 2px black',
+    boxShadow: '0px 0px 1px 1px black',
     backgroundColor:'black',
     },
   },

--- a/src/components/dashboard/Recommendations.js
+++ b/src/components/dashboard/Recommendations.js
@@ -20,12 +20,12 @@ const useStyles = makeStyles((theme) => ({
   cardGrid: {
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
-    paddingRight: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
   },
   movieCard: {
     "&:hover": {
-      boxShadow: "0px 0px 2px 2px black",
+      boxShadow: "0px 0px 1px 1px black",
       backgroundColor: "black",
     },
   },

--- a/src/components/dashboard/Watchlist.js
+++ b/src/components/dashboard/Watchlist.js
@@ -22,12 +22,12 @@ const useStyles = makeStyles((theme) => ({
   cardGrid: {
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(4),
-    paddingRight: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
   },
   movieCard: {
     "&:hover": {
-    boxShadow: '0px 0px 2px 2px black',
+    boxShadow: '0px 0px 1px 1px black',
     backgroundColor:'black',
     },
   },


### PR DESCRIPTION
# Description

Reduces the box shadow and padding around the movie cards. On desktop the spacing gets giant on a larger screen and on mobile making the spacing smaller gives more screen real estate to the image itself. 

## Type of change

- [x] Minor tweak to aesthetics


## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Staging enviorment

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
